### PR TITLE
Sort Roles by ID instead of Version names

### DIFF
--- a/tasks/update-requirement.yml
+++ b/tasks/update-requirement.yml
@@ -26,9 +26,10 @@
 - name: Use the ugliest hack in the world to find the highest version.
   set_fact:
     highest_role_version: >-
-      {%- for version_data in role_versions | sort(attribute='name', reverse=True) -%}
+      {%- for version_data in role_versions | sort(attribute='id', reverse=True) -%}
         {%- if loop.first -%}
           {{ version_data.name }}
+          {% break %}
         {%- endif -%}
       {%- endfor -%}
 


### PR DESCRIPTION
I don't have ansible experience but after watching your video I thought I could help. After looking into the Galaxy API I noticed that the id is greater in the new versions so by sorting the id instead it removes any complexity and bugs in sorting by the names e.g. `1.0.9`